### PR TITLE
Fix compiler warnings

### DIFF
--- a/contracts/AttributeStore.sol
+++ b/contracts/AttributeStore.sol
@@ -7,13 +7,13 @@ library AttributeStore {
 
     function getAttribute(Data storage self, bytes32 _UUID, string _attrName)
     public view returns (uint) {
-        bytes32 key = keccak256(_UUID, _attrName);
+        bytes32 key = keccak256(abi.encodePacked(_UUID, _attrName));
         return self.store[key];
     }
 
     function setAttribute(Data storage self, bytes32 _UUID, string _attrName, uint _attrVal)
     public {
-        bytes32 key = keccak256(_UUID, _attrName);
+        bytes32 key = keccak256(abi.encodePacked(_UUID, _attrName));
         self.store[key] = _attrVal;
     }
 }


### PR DESCRIPTION
Add abi.encodePacked in keccak256 to make compiler output more legible.